### PR TITLE
[plan-page] : 플랜 상세페이지에서 사용자와 관련된 디자인 및 기능을 구현하였습니다.

### DIFF
--- a/app/src/main/java/com/trip/tripsync/ui/dialog/UserCheckDialogFragment.kt
+++ b/app/src/main/java/com/trip/tripsync/ui/dialog/UserCheckDialogFragment.kt
@@ -1,0 +1,78 @@
+package com.trip.tripsync.ui.dialog
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Observer
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.trip.tripsync.R
+import com.trip.tripsync.databinding.FragmentFriendAddDialogBinding
+import com.trip.tripsync.databinding.FragmentUserCheckDialogBinding
+import com.trip.tripsync.ui.fragment.plan.PlanUserDialogAdapter
+import com.trip.tripsync.ui.fragment.plan.PlanUserNameAdapter
+import com.trip.tripsync.ui.fragment.setup.SharedViewModel
+
+class UserCheckDialogFragment : DialogFragment() {
+
+    private var _binding: FragmentUserCheckDialogBinding? = null
+    private val binding: FragmentUserCheckDialogBinding
+        get() = _binding!!
+
+    private val sharedViewModel: SharedViewModel by activityViewModels()
+    private lateinit var userAdapter : PlanUserDialogAdapter
+
+    override fun onStart() {
+        super.onStart()
+
+        val width = (resources.displayMetrics.widthPixels * 0.85).toInt()
+        val height = ViewGroup.LayoutParams.WRAP_CONTENT
+        dialog?.window?.setLayout(width, height)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+        _binding = FragmentUserCheckDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        initView()
+    }
+
+    private fun initView() {
+        userAdapter = PlanUserDialogAdapter()
+        binding.userCheckRv.adapter = userAdapter
+        binding.userCheckRv.layoutManager= LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+
+        val userTotalCount = binding.userTotalCount
+        sharedViewModel.userList.observe(viewLifecycleOwner, Observer { name ->
+            userAdapter.submitList(name)
+            userTotalCount.text = "총 ${userAdapter.currentList.size.toString()} 명"
+        })
+
+        binding.userCheckBackBtn.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+    companion object {
+        fun newInstance() : UserCheckDialogFragment {
+            return UserCheckDialogFragment()
+        }
+    }
+}

--- a/app/src/main/java/com/trip/tripsync/ui/fragment/plan/PlanFragment.kt
+++ b/app/src/main/java/com/trip/tripsync/ui/fragment/plan/PlanFragment.kt
@@ -19,10 +19,9 @@ import com.trip.tripsync.model.Travel
 import com.trip.tripsync.ui.dialog.ConfirmDialog
 import com.trip.tripsync.ui.fragment.plan.planbookmarklist.PlanBoomarkListDialog
 import com.trip.tripsync.ui.fragment.plan.plansearchlist.PlanSearchListDialog
-import com.trip.tripsync.ui.fragment.setup.NaverMapFragment
 import com.trip.tripsync.ui.fragment.setup.PlanMemoDialog
 import com.trip.tripsync.ui.fragment.setup.SharedViewModel
-import com.google.android.gms.location.LocationServices
+import com.trip.tripsync.ui.dialog.UserCheckDialogFragment
 
 class PlanFragment : Fragment() {
 
@@ -82,6 +81,9 @@ class PlanFragment : Fragment() {
             sharedViewModel.setHint(true)
         }
 
+        binding.planUserCheckBtn.setOnClickListener {
+            showUserCheckDialog()
+        }
 
         binding.planTextView.setOnClickListener {
             showMemoDialog()
@@ -137,6 +139,16 @@ class PlanFragment : Fragment() {
         planUsernameRecycler.adapter = userAdapter
         planUsernameRecycler.layoutManager= LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
 
+        val decoration = ItemDecoration()
+        planUsernameRecycler.addItemDecoration(decoration)
+
+        planUsernameRecycler.setOnClickListener {
+            UserCheckDialogFragment.newInstance().let { dialog ->
+                dialog.isCancelable = false
+                dialog.show(parentFragmentManager, "UserCheckDialog")
+            }
+        }
+
         sharedViewModel.userList.observe(viewLifecycleOwner, Observer { name ->
             userAdapter.submitList(name)
         })
@@ -176,6 +188,13 @@ class PlanFragment : Fragment() {
 
         if (binding.planTextView.text.isNotEmpty()){
             sharedViewModel.setHint(false)
+        }
+    }
+
+    private fun showUserCheckDialog() {
+        UserCheckDialogFragment.newInstance().let { dialog ->
+            dialog.isCancelable = false
+            dialog.show(parentFragmentManager, "UserCheckDialog")
         }
     }
 

--- a/app/src/main/java/com/trip/tripsync/ui/fragment/plan/PlanUserDialogAdapter.kt
+++ b/app/src/main/java/com/trip/tripsync/ui/fragment/plan/PlanUserDialogAdapter.kt
@@ -1,0 +1,50 @@
+package com.trip.tripsync.ui.fragment.plan
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.trip.tripsync.R
+import com.trip.tripsync.databinding.PlanUsernameItemBinding
+import com.trip.tripsync.model.User
+
+class PlanUserDialogAdapter : ListAdapter<User, PlanUserDialogAdapter.ViewHolder>(
+    object : DiffUtil.ItemCallback<User>() {
+        override fun areItemsTheSame(oldItem: User, newItem: User): Boolean {
+            return oldItem == newItem
+        }
+
+        override fun areContentsTheSame(oldItem: User, newItem: User): Boolean {
+            return oldItem == newItem
+        }
+
+    }
+) {
+
+    class ViewHolder(private val binding: PlanUsernameItemBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: User) = with(binding) {
+
+            planUserName.text = item.nickname
+            planUserName.visibility = View.VISIBLE
+
+            Glide.with(itemView)
+                .load(item.profileImg)
+                .error(R.drawable.defalt_profile)
+                .into(planUserProfile)
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = PlanUsernameItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
+    }
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+    override fun getItemCount(): Int {
+        return currentList.size
+    }
+}

--- a/app/src/main/java/com/trip/tripsync/ui/fragment/plan/PlanUserNameAdapter.kt
+++ b/app/src/main/java/com/trip/tripsync/ui/fragment/plan/PlanUserNameAdapter.kt
@@ -1,6 +1,8 @@
 package com.trip.tripsync.ui.fragment.plan
 
+import android.graphics.Rect
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -31,9 +33,6 @@ class PlanUserNameAdapter : ListAdapter<User, PlanUserNameAdapter.ViewHolder>(
                 .load(item.profileImg)
                 .error(R.drawable.defalt_profile)
                 .into(planUserProfile)
-
-
-
         }
     }
 
@@ -42,7 +41,25 @@ class PlanUserNameAdapter : ListAdapter<User, PlanUserNameAdapter.ViewHolder>(
         return ViewHolder(binding)
     }
 
+    private val maxItemCount = 5
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         holder.bind(getItem(position))
+    }
+
+    override fun getItemCount(): Int {
+        return if (super.getItemCount() >= maxItemCount) maxItemCount else super.getItemCount()
+    }
+}
+
+class ItemDecoration : RecyclerView.ItemDecoration() {
+    override fun getItemOffsets(
+        outRect: Rect,
+        view: View,
+        parent: RecyclerView,
+        state: RecyclerView.State
+    ) {
+        super.getItemOffsets(outRect, view, parent, state)
+        val offset = -85
+        outRect.right = offset
     }
 }

--- a/app/src/main/res/layout/fragment_plan.xml
+++ b/app/src/main/res/layout/fragment_plan.xml
@@ -60,11 +60,26 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="5dp"
+                android:orientation="horizontal"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/plan_date"
                 tools:listitem="@layout/plan_username_item" />
 
+            <TextView
+                android:id="@+id/plan_user_check_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="자세히보기"
+                android:gravity="center"
+                android:layout_marginEnd="10sp"
+                android:paddingVertical="7dp"
+                android:paddingHorizontal="15dp"
+                android:background="@drawable/button_sub_solid"
+                app:layout_constraintBottom_toBottomOf="@+id/plan_username_recycler"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@+id/plan_username_recycler" />
 
             <androidx.cardview.widget.CardView
                 android:id="@+id/plan_cardview"

--- a/app/src/main/res/layout/fragment_user_check_dialog.xml
+++ b/app/src/main/res/layout/fragment_user_check_dialog.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/view_round_white_6"
+    android:paddingHorizontal="20dp"
+    android:paddingVertical="30dp">
+
+    <TextView
+        android:id="@+id/user_check_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="추가한 일행 목록 :"
+        android:textSize="18sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/user_total_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+        android:layout_marginStart="10dp"
+        app:layout_constraintBottom_toBottomOf="@+id/user_check_title"
+        app:layout_constraintStart_toEndOf="@+id/user_check_title"
+        app:layout_constraintTop_toTopOf="@+id/user_check_title" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/user_check_rv"
+        android:layout_width="match_parent"
+        android:layout_height="250dp"
+        android:layout_marginTop="20sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/user_check_title" />
+
+    <TextView
+        android:id="@+id/user_check_back_btn"
+        android:layout_width="165dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:background="@drawable/button_sub_solid"
+        android:gravity="center|center_horizontal"
+        android:paddingVertical="16dp"
+        android:text="뒤로가기"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="@+id/user_check_rv"
+        app:layout_constraintStart_toStartOf="@+id/user_check_rv"
+        app:layout_constraintTop_toBottomOf="@+id/user_check_rv" />
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/plan_username_item.xml
+++ b/app/src/main/res/layout/plan_username_item.xml
@@ -9,15 +9,25 @@
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/plan_user_profile"
-        android:layout_width="50dp"
-        android:layout_height="50dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
         android:background="@drawable/button_sub_solid"
         android:scaleType="centerCrop"
         app:shapeAppearance="@style/Circle"
         app:shapeAppearanceOverlay="@style/Circle"
-        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/plan_user_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="10dp"
+        android:text="닉네임"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/plan_user_profile"
+        app:layout_constraintStart_toEndOf="@+id/plan_user_profile"
+        app:layout_constraintTop_toTopOf="@+id/plan_user_profile" />
 
 
 


### PR DESCRIPTION
## PlanFragement
- 사용자 프로필 사진 겹칠 수 있도록 offset 값 조절
- 최대 5개 까지 미리볼 수 있도록 item 갯수 설정
- `자세히보기` 버튼 클릭 시 5명 외에 총 사용자의 자세한 정보를 볼 수 있도록 다이얼로그 구현
- 다이얼로그 내부에 총 몇명인지 알 수 있도록 total count 설정
- 다이얼로그 내부에 프로필 이미지, 유저 닉네임 나타내어 줌

## 주요 변동 파일
PlanFragment

## 새롭게 생성한 파일
fragment_user_check_dialog.xml, UserCheckDialogFragment.kt, PlanUserDialogAdapter.kt